### PR TITLE
Add lifecycle Provisioned Throughput

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -162,6 +162,7 @@ resource "aws_msk_cluster" "this" {
   lifecycle {
     ignore_changes = [
       broker_node_group_info[0].storage_info[0].ebs_storage_info[0].volume_size,
+      broker_node_group_info[0].storage_info[0].ebs_storage_info[0].provisioned_throughput # https://github.com/hashicorp/terraform-provider-aws/issues/24914#issuecomment-1640761547
     ]
   }
 


### PR DESCRIPTION
Added ignore changes in provisioned throughput `broker_node_group_info[0].storage_info[0].ebs_storage_info[0].provisioned_throughput` due to [AWS Provider issue ](https://github.com/hashicorp/terraform-provider-aws/issues/24914#issuecomment-1640761547)