### PR TITLE
Fix: `msk_configuration` resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ No modules.
 | <a name="input_cluster_source_policy_documents"></a> [cluster\_source\_policy\_documents](#input\_cluster\_source\_policy\_documents) | Source policy documents for cluster policy | `list(string)` | `null` | no |
 | <a name="input_configuration_arn"></a> [configuration\_arn](#input\_configuration\_arn) | ARN of an externally created configuration to use | `string` | `null` | no |
 | <a name="input_configuration_description"></a> [configuration\_description](#input\_configuration\_description) | Description of the configuration | `string` | `null` | no |
+| <a name="input_configuration_kafka_versions"></a> [configuration\_kafka\_versions](#input\_configuration\_kafka\_versions) | List of Apache Kafka versions which can use this configuration | `set(string)` | `null` | no |
 | <a name="input_configuration_name"></a> [configuration\_name](#input\_configuration\_name) | Name of the configuration | `string` | `null` | no |
 | <a name="input_configuration_revision"></a> [configuration\_revision](#input\_configuration\_revision) | Revision of the externally created configuration to use | `number` | `null` | no |
 | <a name="input_configuration_server_properties"></a> [configuration\_server\_properties](#input\_configuration\_server\_properties) | Contents of the server.properties file. Supported properties are documented in the [MSK Developer Guide](https://docs.aws.amazon.com/msk/latest/developerguide/msk-configuration-properties.html) | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -252,8 +252,8 @@ resource "random_id" "this" {
   count = var.create && var.create_configuration ? 1 : 0
 
   keepers = {
-    # Generate a new id each time a new version of server property is used
-    kafka_version = var.kafka_version
+    # Generate a new id each time a new version is used.  If this isnt used, the same msk_config name is used and the plan fails.
+    kafka_version = join(",", coalesce(var.configuration_kafka_versions, [""]))
   }
 
   byte_length = 8
@@ -264,9 +264,8 @@ resource "aws_msk_configuration" "this" {
 
   name              = format("%s-%s", coalesce(var.configuration_name, var.name), random_id.this[0].dec)
   description       = var.configuration_description
-  kafka_versions    = [var.kafka_version]
   server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])
-
+  kafka_versions    = var.configuration_kafka_versions
   lifecycle {
     create_before_destroy = true
   }

--- a/main.tf
+++ b/main.tf
@@ -253,8 +253,7 @@ resource "random_id" "this" {
 
   keepers = {
     # Generate a new id each time a new version of server property is used
-    kafka_version     = var.kafka_version
-    server_properties = join("\n", [for k, v in var.configuration_server_properties : format("%s = %s", k, v)])
+    kafka_version = var.kafka_version
   }
 
   byte_length = 8

--- a/variables.tf
+++ b/variables.tf
@@ -202,6 +202,12 @@ variable "configuration_description" {
   default     = null
 }
 
+variable "configuration_kafka_versions" {
+  description = "List of Apache Kafka versions which can use this configuration"
+  type        = set(string)
+  default     = null
+}
+
 variable "configuration_server_properties" {
   description = "Contents of the server.properties file. Supported properties are documented in the [MSK Developer Guide](https://docs.aws.amazon.com/msk/latest/developerguide/msk-configuration-properties.html)"
   type        = map(string)


### PR DESCRIPTION
This release allow a `null` value to be passed into the `kafka_versions` argument for the MSK Configuration resource.  It allows all kafka versions to use the config.